### PR TITLE
Move node-sass to "peerDependencies" group

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "chroma-js": "^1.1.1",
     "extend": "^3.0.0",
     "lodash": "^4.1.4",
-    "node-sass": ">=3.0.0",
     "node-sass-utils": "^1.1.2"
+  },
+  "peerDependencies": {
+    "node-sass": ">=3.0.0"
   },
   "devDependencies": {
     "coffee-script": "^1.10.0",


### PR DESCRIPTION
This prevents chromatic-sass from installing it's own version of node-sass.