### PR TITLE
Fix spelling of “dodge” in chromatic-blend API docs

### DIFF
--- a/api.md
+++ b/api.md
@@ -138,7 +138,7 @@ $foo: chromatic-mix(red, blue, .5, 'rgb');
 ```
 
 ### chromatic-blend
-Blends two colors using RGB channel-wise blend functions. Valid blend modes are `multiply`, `darken`, `lighten`, `screen`, `overlay`, `burn`, and `dogde`.
+Blends two colors using RGB channel-wise blend functions. Valid blend modes are `multiply`, `darken`, `lighten`, `screen`, `overlay`, `burn`, and `dodge`.
 ```Sass
 // <color0>, <color1>, <mode>
 @function chromatic-blend($color0, $color1, $mode) { ... }


### PR DESCRIPTION
`dodge` is the spelling that the function supports: see https://gka.github.io/chroma.js/#chroma-blend

Affects https://github.com/bugsnag/chromatic-sass/blob/master/api.md#chromatic-blend.